### PR TITLE
Remove test for not null screen ID and name in app errors table (close #18)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ snowplow-unified 0.2.0 (2024-0X-XX)
 ## Fixes
 - Consider screen view ID from the screen view context (#14)
 - Fix link to incorrect FAQ in README
+- Remove test for not null screen ID and name in app errors table
 
 ## Upgrading
 Bump the snowplow-unified version in your `packages.yml` file.

--- a/models/optional_modules/app_errors/app_errors.yml
+++ b/models/optional_modules/app_errors/app_errors.yml
@@ -99,16 +99,8 @@ models:
         description: '{{ doc("col_open_idfa") }}'
       - name: screen_id
         description: '{{ doc("col_screen_id") }}'
-        tests:
-          - not_null:
-              config:
-                enabled: '{{var("snowplow__enable_app_errors", false)}}'
       - name: screen_name
         description: '{{ doc("col_screen_name") }}'
-        tests:
-          - not_null:
-              config:
-                enabled: '{{var("snowplow__enable_app_errors", false)}}'
       - name: screen_activity
         description: '{{ doc("col_screen_activity") }}'
       - name: screen_fragment

--- a/models/optional_modules/app_errors/scratch/app_errors_scratch.yml
+++ b/models/optional_modules/app_errors/scratch/app_errors_scratch.yml
@@ -99,16 +99,8 @@ models:
         description: '{{ doc("col_open_idfa") }}'
       - name: screen_id
         description: '{{ doc("col_screen_id") }}'
-        tests:
-          - not_null:
-              config:
-                enabled: '{{var("snowplow__enable_app_errors", false) and var("snowplow__enable_screen_context", false) }}'
       - name: screen_name
         description: '{{ doc("col_screen_name") }}'
-        tests:
-          - not_null:
-              config:
-                enabled:  '{{var("snowplow__enable_app_errors", false) and var("snowplow__enable_screen_context", false) }}'
       - name: screen_activity
         description: '{{ doc("col_screen_activity") }}'
       - name: screen_fragment


### PR DESCRIPTION
Issue #18

## Description

This PR removes not null tests on the `screen_id` and `screen_name` columns in the `snowplow_unified_app_errors` table.
They are not necessary as the app error events may be sent before a screen view event is tracked.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Checklist
- [ ] 🎉 I have verified that these changes work locally
- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md
### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed