### PR TITLE
Add headset to the list of recognized platforms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ snowplow-unified 0.2.0 (2024-0X-XX)
 
 ## Features
 - Adds user stitching to the users table (enabled with `snowplow__session_stitching`)
+- Adds "headset" to the list of recognized platforms
 
 ## Fixes
 - Consider screen view ID from the screen view context (#14)

--- a/macros/unify_fields_query.sql
+++ b/macros/unify_fields_query.sql
@@ -101,7 +101,8 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
           when platform = 'app' then 'General App'
           when platform = 'tv' then 'Connected TV'
           when platform = 'cnsl' then 'Games Console'
-          when platform = 'iot' then 'Internet of Things' end as platform_name
+          when platform = 'iot' then 'Internet of Things'
+          when platform = 'headset' then 'AR/VR Headset' end as platform_name
 
     from {{ ref('snowplow_unified_base_events_this_run') }} as ev
 


### PR DESCRIPTION
## Description

Ahead of adding the visionOS support in the iOS tracker, this PR adds the new `headset` platform value to the list of recognized platforms.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature

## Checklist
- [x] 🎉 I have verified that these changes work locally
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md
### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed
