### PR TITLE
Move cluster by to macros to allow users to overwrite (Close #11)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ XXX
 - Add new passthrough aggregations to the views, sessions, and users table, enabled using `snowplow__view/session/user_aggregations`
 - Reorder and add some additional context fields to derived tables (non-breaking change)
 - Add `snowplow__custom_sql` to allow adding custom sql to the `snowplow_unified_base_events_this_run` and `snowplow_unified_events_this_run` models
+- Add macro to define cluster-by for tables to allow users to overwrite this if required
 
 ## Fixes
 - Fix a bug where if you ran the package in a period with no data, and had list all events enabled, the package would error rather than complete

--- a/docs/markdown/snowplow_unified_macros_docs.md
+++ b/docs/markdown/snowplow_unified_macros_docs.md
@@ -242,3 +242,15 @@ The sql needed to make the warehosue specific transformations to retrieve the co
 
 {% endraw %}
 {% enddocs %}
+
+{% docs macro_cluster_by_values %}
+{% raw %}
+
+A macro to manage the cluster by fields for various models in the package.
+
+#### Returns
+
+The field to cluster by based on model name and target type.
+
+{% endraw %}
+{% enddocs %}

--- a/macros/field_definitions/cluster_by_values.sql
+++ b/macros/field_definitions/cluster_by_values.sql
@@ -1,0 +1,30 @@
+{% macro unified_cluser_by(model) %}
+    {{ return(adapter.dispatch('unified_cluser_by', 'snowplow_unified')(model)) }}
+{% endmacro %}
+
+
+{% macro default__unified_cluser_by(model) %}
+    {% if model == 'lifecycle_manifest' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(start_tstamp)"])) }}
+    {% elif model == 'app_errors' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(derived_tstamp)"])) }}
+    {% elif model == 'consent_log' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["event_id","user_identifier"], snowflake_val=["to_date(load_tstamp)"])) }}
+    {% elif model == 'conversions' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier","session_identifier"], snowflake_val=["to_date(cv_tstamp)"])) }}
+    {% elif model == 'web_vitals' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["view_id","user_identifier"], snowflake_val=["to_date(derived_tstamp)"])) }}
+    {% elif model == 'sessions' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier"], snowflake_val=["to_date(start_tstamp)"])) }}
+    {% elif model == 'users' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_id","user_identifier"], snowflake_val=["to_date(start_tstamp)"])) }}
+    {% elif model == 'users_aggs' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier"])) }}
+    {% elif model == 'views' %}
+        {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier","session_identifier"], snowflake_val=["to_date(start_tstamp)"])) }}
+    {% else %}
+        {{ exceptions.raise_compiler_error(
+      "Snowplow Error: Model "~model~" not defined for cluster by."
+      ) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -99,4 +99,9 @@ macros:
     description: '{{ doc("macro_event_counts_string_query") }}'
   - name: conversion_query
     description: '{{ doc("macro_conversion_query") }}'
-
+  - name: cluster_by_values
+    description: '{{ doc("macro_cluster_by_values") }}'
+    arguments:
+      - name: model
+        type: string
+        description: Short name of model to select which fields to cluster by

--- a/models/base/manifest/snowplow_unified_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowplow_unified_base_sessions_lifecycle_manifest.sql
@@ -16,7 +16,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(start_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('lifecycle_manifest'),
     full_refresh=snowplow_unified.allow_refresh(),
     tags=["manifest"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/models/optional_modules/app_errors/snowplow_unified_app_errors.sql
+++ b/models/optional_modules/app_errors/snowplow_unified_app_errors.sql
@@ -16,7 +16,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "derived_tstamp",
       "data_type": "timestamp"
     }, databricks_val='derived_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["session_identifier"], snowflake_val=["to_date(derived_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('app_errors'),
     tags=["derived"],
     enabled=var("snowplow__enable_app_errors", false),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/models/optional_modules/consent/snowplow_unified_consent_log.sql
+++ b/models/optional_modules/consent/snowplow_unified_consent_log.sql
@@ -18,7 +18,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "derived_tstamp",
       "data_type": "timestamp"
     }, databricks_val = 'derived_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["event_id","user_identifier"], snowflake_val=["to_date(load_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('consent_log'),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',

--- a/models/optional_modules/conversions/snowplow_unified_conversions.sql
+++ b/models/optional_modules/conversions/snowplow_unified_conversions.sql
@@ -18,7 +18,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "cv_tstamp",
       "data_type": "timestamp"
     }, databricks_val='cv_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier","session_identifier"], snowflake_val=["to_date(cv_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('conversions'),
     tags=["derived"],
     post_hook="{{ snowplow_unified.stitch_user_identifiers(
       enabled=var('snowplow__conversion_stitching')

--- a/models/optional_modules/core_web_vitals/snowplow_unified_web_vitals.sql
+++ b/models/optional_modules/core_web_vitals/snowplow_unified_web_vitals.sql
@@ -18,7 +18,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "derived_tstamp",
       "data_type": "timestamp"
     }, databricks_val = 'derived_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["view_id","user_identifier"], snowflake_val=["to_date(derived_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('web_vitals'),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',

--- a/models/sessions/snowplow_unified_sessions.sql
+++ b/models/sessions/snowplow_unified_sessions.sql
@@ -17,7 +17,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier"], snowflake_val=["to_date(start_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('sessions'),
     tags=["derived"],
     post_hook="{{ snowplow_unified.stitch_user_identifiers(
       enabled=var('snowplow__session_stitching')

--- a/models/users/scratch/snowplow_unified_users_aggs.sql
+++ b/models/users/scratch/snowplow_unified_users_aggs.sql
@@ -11,7 +11,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier"]),
+    cluster_by=snowplow_unified.unified_cluser_by('users_aggs'),
     sort='user_identifier',
     dist='user_identifier',
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))

--- a/models/users/snowplow_unified_users.sql
+++ b/models/users/snowplow_unified_users.sql
@@ -21,7 +21,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
     post_hook="{{ snowplow_unified.stitch_user_identifiers(
       enabled=var('snowplow__session_stitching')
       ) }}",
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["user_id","user_identifier"], snowflake_val=["to_date(start_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('users'),
     tags=["derived"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
     tblproperties={

--- a/models/views/snowplow_unified_views.sql
+++ b/models/views/snowplow_unified_views.sql
@@ -17,7 +17,7 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
       "field": "start_tstamp",
       "data_type": "timestamp"
     }, databricks_val='start_tstamp_date'),
-    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["user_identifier","session_identifier"], snowflake_val=["to_date(start_tstamp)"]),
+    cluster_by=snowplow_unified.unified_cluser_by('views'),
     tags=["derived"],
     post_hook="{{ snowplow_unified.stitch_user_identifiers(
       enabled=var('snowplow__view_stitching')


### PR DESCRIPTION
## Description

This PR adds a new macro that are used to define the cluster by fields for models, which allows users to overwrite this if required. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Implements #11 
https://snplow.atlassian.net/browse/PE-6036

## Checklist
- [x] 🎉 I have verified that these changes work locally
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
## [optional] What gif best describes this PR or how it makes you feel?
