### PR TITLE
Add custom sql variable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ XXX
 ## Features
 - Add new passthrough aggregations to the views, sessions, and users table, enabled using `snowplow__view/session/user_aggregations`
 - Reorder and add some additional context fields to derived tables (non-breaking change)
+- Add `snowplow__custom_sql` to allow adding custom sql to the `snowplow_unified_base_events_this_run` and `snowplow_unified_events_this_run` models
 
 ## Fixes
 - Fix a bug where if you ran the package in a period with no data, and had list all events enabled, the package would error rather than complete

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -67,8 +67,9 @@ vars:
     # please refer to the macros within identifiers.sql for default values
     snowplow__session_identifiers: []
     snowplow__user_identifiers: []
-    
+    # snowplow__session_sql: 'e.domain_sessionid'
     # snowplow__user_sql: 'e.domain_userid'
+    # snowplow__custom_sql: ''
     snowplow__user_stitching_id: user_id
     # filter your data:
     snowplow__app_id: []

--- a/models/base/scratch/snowplow_unified_base_events_this_run.sql
+++ b/models/base/scratch/snowplow_unified_base_events_this_run.sql
@@ -94,7 +94,8 @@ You may obtain a copy of the Snowplow Personal and Academic License Version 1.0 
                               snowplow_events_database=var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') if target.type in ['databricks'] else var('snowplow__atomic_schema', 'atomic'),
                               snowplow_events_schema=var('snowplow__atomic_schema', 'atomic'),
                               snowplow_events_table=var('snowplow__events_table', 'events'),
-                              entities_or_sdes=contexts
+                              entities_or_sdes=contexts,
+                              custom_sql=var('snowplow__custom_sql', none)
                               ) %}
 
 


### PR DESCRIPTION
## Description

Adds support for the `custom_sql` argument to the base events this run table to allow users to add SQL to these models without needing to fully overwrite the macros.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
https://snplow.atlassian.net/browse/PE-6049

## Checklist
- [x] 🎉 I have verified that these changes work locally
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?
- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
## [optional] What gif best describes this PR or how it makes you feel?
