### PR TITLE
Add option to use refer in channel classification if mkt is null

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+snowplow-unified 0.4.1 (2024-0X-XX)
+---------------------------------------
+## Summary
+XXX
+
+## Features
+- New `snowplow__use_refr_if_mkt_null` variable to use `refr_` fields if `mkt_` ones are null in default channel group classification
+
+## Fixes
+- Fix an issue in the channel group classification where direct channels were sometimes ignored due to string checks
+
+## Upgrading
+Bump the snowplow-unified version in your `packages.yml` file. 
+
 snowplow-unified 0.4.0 (2024-03-25)
 ---------------------------------------
 ## Summary

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -65,6 +65,7 @@ vars:
     snowplow__start_date: '2020-01-01'
     # snowplow__total_all_conversions: false
     snowplow__upsert_lookback_days: 30
+    snowplow__use_refr_if_mkt_null: false 
     
     # please refer to the macros within identifiers.sql for default values
     snowplow__session_identifiers: []

--- a/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
+++ b/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
@@ -86,7 +86,12 @@ with session_firsts as (
 
     from {{ ref('snowplow_unified_events_this_run') }} ev
     left join
-        {{ ref(var('snowplow__ga4_categories_seed')) }} c on lower(trim(ev.mkt_source)) = lower(c.source)
+        {{ ref(var('snowplow__ga4_categories_seed')) }} c on 
+        {% if var('snowplow__use_refr_if_mkt_null', false) %}
+        lower(trim(coalesce(ev.mkt_source, ev.refr_source)) = lower(c.source)
+        {% else %}
+          lower(trim(ev.mkt_source)) = lower(c.source)
+        {% endif %}
     left join
         {{ ref(var('snowplow__rfc_5646_seed')) }} l on lower(ev.br_lang) = lower(l.lang_tag)
     left join

--- a/models/views/scratch/snowplow_unified_views_this_run.sql
+++ b/models/views/scratch/snowplow_unified_views_this_run.sql
@@ -92,7 +92,12 @@ with prep as (
 
     from {{ ref('snowplow_unified_events_this_run') }} as ev
 
-    left join {{ ref(var('snowplow__ga4_categories_seed')) }} c on lower(trim(ev.mkt_source)) = lower(c.source)
+    left join {{ ref(var('snowplow__ga4_categories_seed')) }} c on 
+      {% if var('snowplow__use_refr_if_mkt_null', false) %}
+        lower(trim(coalesce(ev.mkt_source, ev.refr_source)) = lower(c.source)
+      {% else %}
+        lower(trim(ev.mkt_source)) = lower(c.source)
+      {% endif %}
 
     where ev.event_name in ('page_view', 'screen_view')
     and ev.view_id is not null


### PR DESCRIPTION
## Description

FOR DISCUSSION

This PR adds a var to enable the use of refr fields in place of mkt fields when they are null in the default channel group query. This is off by default to make this a non-breaking change (and it is non-GA type behaviour. This has been mentioned a few times and done a few times by customers (see [here](https://github.com/snowplow-proservices/com.usgoldbureau-snowplow-pipeline/commit/54bbcea255852cae0843de1242663d0ea6acbd84)). 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents


## Checklist
- [ ] ❗️ I have verified that these changes work on Redshift
- [ ] 💣 Is your change a breaking change?
- [x] 📖 I have updated the CHANGELOG.md

### Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?
- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [ ] 🙅 no documentation needed