### PR TITLE
Fix syntax when `snowplow__use_refr_if_mkt_null` enabled

### DIFF
--- a/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
+++ b/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
@@ -88,7 +88,7 @@ with session_firsts as (
     left join
         {{ ref(var('snowplow__ga4_categories_seed')) }} c on 
         {% if var('snowplow__use_refr_if_mkt_null', false) %}
-        lower(trim(coalesce(ev.mkt_source, ev.refr_source)) = lower(c.source)
+        lower(trim(coalesce(ev.mkt_source, ev.refr_source))) = lower(c.source)
         {% else %}
           lower(trim(ev.mkt_source)) = lower(c.source)
         {% endif %}


### PR DESCRIPTION
## Description

This PR fixes a syntax error when the `snowplow__use_refr_if_mkt_null` var is enabled.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Zendesk 41345

## Checklist

- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here)
- [x] 🙅 no documentation needed
