### PR TITLE
Missing parenthese in join fuction

### DIFF
--- a/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
+++ b/models/sessions/scratch/snowplow_unified_sessions_this_run.sql
@@ -88,7 +88,7 @@ with session_firsts as (
     left join
         {{ ref(var('snowplow__ga4_categories_seed')) }} c on 
         {% if var('snowplow__use_refr_if_mkt_null', false) %}
-        lower(trim(coalesce(ev.mkt_source, ev.refr_source)) = lower(c.source)
+        lower(trim(coalesce(ev.mkt_source, ev.refr_source))) = lower(c.source)
         {% else %}
           lower(trim(ev.mkt_source)) = lower(c.source)
         {% endif %}


### PR DESCRIPTION
There is a missing end parentheses in the sql that cause the model to fail when the var snowplow__use_refr_if_mkt_null is set to true
