### PR TITLE
Move tests view in session values to this run (Close #56)

### DIFF
--- a/tests/page_screen_views/snowplow_tests_view_in_session_values.sql
+++ b/tests/page_screen_views/snowplow_tests_view_in_session_values.sql
@@ -13,7 +13,7 @@ with prep as (
     count(*) - count(distinct view_in_session_index)  as all_minus_dist_pvisi,
     count(*) - count(distinct view_id) as all_minus_dist_pvids
 
-  from {{ ref('snowplow_unified_views') }}
+  from {{ ref('snowplow_unified_views_this_run') }}
   group by 1
 )
 


### PR DESCRIPTION
## Description

This PR moves the views in session to run on the page views this run table instead - because we fully reprocess a session this should have the same effect but without the need to scan the full table.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #56

## Checklist

- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here)
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbzZxMmVtMDRueDJvdzhkNzhxamoyMzgwdXRkMjJvZHZ2YWw5cGFmbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fnQgZ3dmFYKX3dS5gV/giphy.webp)