### PR TITLE
Use row_number to deduplicate in Redshift

### DIFF
--- a/models/views/scratch/snowplow_unified_views_this_run.sql
+++ b/models/views/scratch/snowplow_unified_views_this_run.sql
@@ -72,7 +72,7 @@ with prep as (
       {{ snowplow_unified.mobile_context_fields('ev')}}
     {% endif %}
 
-    {% if target.type in ['postgres','spark'] %}
+    {% if target.type in ['postgres','spark','redshift'] %}
     ,row_number() over (partition by ev.view_id order by ev.derived_tstamp, ev.dvce_created_tstamp) as view_id_dedupe_index
     {% endif %}
 
@@ -106,7 +106,7 @@ with prep as (
       {{ snowplow_unified.filter_bots('ev') }}
     {% endif %}
 
-    {% if target.type not in ['postgres','spark'] %}
+    {% if target.type not in ['postgres','spark','redshift'] %}
       qualify row_number() over (partition by ev.view_id order by ev.derived_tstamp, ev.dvce_created_tstamp) = 1
     {% endif %}
 )
@@ -170,7 +170,7 @@ with prep as (
   left join {{ ref('snowplow_unified_pv_scroll_depth') }} sd
   on p.view_id = sd.view_id and p.session_identifier = sd.session_identifier
 
-  {% if target.type in ['postgres','spark'] %}
+  {% if target.type in ['postgres','spark','redshift'] %}
     where view_id_dedupe_index = 1
   {% endif %}
 


### PR DESCRIPTION
## Description

A user has reported the inability to run the package after upgrading to Redshift version: 1.0.106767. Investigation revealed that switching to row_number form using qualify unblocks them therefore we will "revert" to this logic, similar to how it was in the snowplow_web package and how it already works for postgres/spark. This is used both for creating the views and sessions table. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


## Checklist

- [ ] 💣 Is your change a breaking change?
- [ ] 📖 I have updated the CHANGELOG.md

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📓 internal package docs (ymls, macros, readme, if applicable)
- [ ] 📕 I have raised a [Snowplow documentation](https://github.com/snowplow/documentation) PR if applicable (Link here)
- [ ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

